### PR TITLE
Added config to use ingredients when creating a map

### DIFF
--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -20,7 +20,9 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.item.ItemStack;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.registry.Registry;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 
 public class Image2Map implements ModInitializer {
@@ -61,24 +63,24 @@ public class Image2Map implements ModInitializer {
                         }
 
                         ItemStack stack = MapRenderer.render(image, source.getWorld(), pos.x, pos.z, player);
-
+                        
                         boolean validIngredients = true;
-                        ItemStack mainHandIngredient = ItemStack.fromTag(CONFIG.mainHandIngredient);
+                        ItemStack mainHandIngredient = new ItemStack(Registry.ITEM.get(Identifier.tryParse(CONFIG.mainHandIngredientId)), 1);
                         if (!mainHandIngredient.isEmpty()) {
                         	validIngredients = player.getMainHandStack().isItemEqual(mainHandIngredient)
-                    				&& player.getMainHandStack().getCount() >= mainHandIngredient.getCount();
+                    				&& player.getMainHandStack().getCount() >= CONFIG.mainHandIngredientAmount;
                         }
-                        ItemStack offHandIngredient = ItemStack.fromTag(CONFIG.offHandIngredient);
+                        ItemStack offHandIngredient = new ItemStack(Registry.ITEM.get(Identifier.tryParse(CONFIG.offHandIngredientId)), 1);
                         if (!offHandIngredient.isEmpty()) {
                         	validIngredients &= player.getOffHandStack().isItemEqual(offHandIngredient)
-                    				&& player.getOffHandStack().getCount() >= offHandIngredient.getCount();
+                    				&& player.getOffHandStack().getCount() >= CONFIG.offHandIngredientAmount;
                         }
                         if (validIngredients) {
                         	if (!mainHandIngredient.isEmpty()) {
-                        		player.getMainHandStack().split(mainHandIngredient.getCount());
+                        		player.getMainHandStack().split(CONFIG.mainHandIngredientAmount);
                         	}
                         	if (!offHandIngredient.isEmpty()) {
-                        		player.getOffHandStack().split(offHandIngredient.getCount());
+                        		player.getOffHandStack().split(CONFIG.offHandIngredientAmount);
                         	}
                         	
                         	source.sendFeedback(new LiteralText("Done!"), false);
@@ -89,9 +91,11 @@ public class Image2Map implements ModInitializer {
                             }
                         } else {
                         	source.sendFeedback(new LiteralText(String.format("Missing crafting ingredients!\nRequired:%s%s",
-                        			!mainHandIngredient.isEmpty() ? String.format("\n  Main hand: %d %s", mainHandIngredient.getCount(),
+                        			!mainHandIngredient.isEmpty() ? String.format("\n  Main hand: %s%s",
+                        					(CONFIG.mainHandIngredientAmount > 0 ? CONFIG.mainHandIngredientAmount + " " : ""),
                         					new TranslatableText(mainHandIngredient.getTranslationKey()).getString()) : "",
-                        			!offHandIngredient.isEmpty() ? String.format("\n  Off hand: %d %s", offHandIngredient.getCount(),
+                        			!offHandIngredient.isEmpty() ? String.format("\n  Off hand: %s%s",
+                        					CONFIG.offHandIngredientAmount > 0 ? CONFIG.offHandIngredientAmount + " " : "",
                         					new TranslatableText(offHandIngredient.getTranslationKey()).getString()) : "")), false);
                         }
 

--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -75,6 +75,7 @@ public class Image2Map implements ModInitializer {
                         	validIngredients &= player.getOffHandStack().isItemEqual(offHandIngredient)
                     				&& player.getOffHandStack().getCount() >= CONFIG.offHandIngredientAmount;
                         }
+                        
                         if (validIngredients) {
                         	if (!mainHandIngredient.isEmpty()) {
                         		player.getMainHandStack().split(CONFIG.mainHandIngredientAmount);
@@ -90,13 +91,22 @@ public class Image2Map implements ModInitializer {
                                 player.world.spawnEntity(itemEntity);
                             }
                         } else {
-                        	source.sendFeedback(new LiteralText(String.format("Missing crafting ingredients!\nRequired:%s%s",
-                        			!mainHandIngredient.isEmpty() ? String.format("\n  Main hand: %s%s",
-                        					(CONFIG.mainHandIngredientAmount > 0 ? CONFIG.mainHandIngredientAmount + " " : ""),
-                        					new TranslatableText(mainHandIngredient.getTranslationKey()).getString()) : "",
-                        			!offHandIngredient.isEmpty() ? String.format("\n  Off hand: %s%s",
-                        					CONFIG.offHandIngredientAmount > 0 ? CONFIG.offHandIngredientAmount + " " : "",
-                        					new TranslatableText(offHandIngredient.getTranslationKey()).getString()) : "")), false);
+                        	StringBuilder sb = new StringBuilder("Missing crafting ingredients!\nRequired:");
+                        	if (!mainHandIngredient.isEmpty()) {
+                        		sb.append("\n  Main hand: ");
+                        		if (CONFIG.mainHandIngredientAmount > 0) {
+                        			sb.append(CONFIG.mainHandIngredientAmount + " ");
+                        		}
+                        		sb.append((new TranslatableText(mainHandIngredient.getTranslationKey())).getString());
+                        	}
+                        	if (!offHandIngredient.isEmpty()) {
+                        		sb.append("\n  Off hand: ");
+                        		if (CONFIG.offHandIngredientAmount > 0) {
+                        			sb.append(CONFIG.offHandIngredientAmount + " ");
+                        		}
+                        		sb.append((new TranslatableText(offHandIngredient.getTranslationKey())).getString());
+                        	}
+                        	source.sendFeedback(new LiteralText(sb.toString()), false);
                         }
 
                         return 1;

--- a/src/main/java/space/essem/image2map/config/Image2MapConfig.java
+++ b/src/main/java/space/essem/image2map/config/Image2MapConfig.java
@@ -3,6 +3,9 @@ package space.essem.image2map.config;
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundTag;
 
 @Config(name = "image2map")
 public class Image2MapConfig implements ConfigData {
@@ -11,4 +14,10 @@ public class Image2MapConfig implements ConfigData {
 
   @Comment(value = "Specifies the needed permission level to use the /mapcreate command")
   public int minPermLevel = 2;
+  
+  @Comment(value = "The ingredient to be held in the player's main hand when creating a map")
+  public CompoundTag mainHandIngredient = new ItemStack(Items.MAP, 1).toTag(new CompoundTag());
+  
+  @Comment(value = "The ingredient to be held in the player's off hand when creating a map")
+  public CompoundTag offHandIngredient = new ItemStack(Items.INK_SAC, 1).toTag(new CompoundTag());
 }

--- a/src/main/java/space/essem/image2map/config/Image2MapConfig.java
+++ b/src/main/java/space/essem/image2map/config/Image2MapConfig.java
@@ -3,9 +3,6 @@ package space.essem.image2map.config;
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 import me.sargunvohra.mcmods.autoconfig1u.shadowed.blue.endless.jankson.Comment;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.nbt.CompoundTag;
 
 @Config(name = "image2map")
 public class Image2MapConfig implements ConfigData {
@@ -15,9 +12,15 @@ public class Image2MapConfig implements ConfigData {
   @Comment(value = "Specifies the needed permission level to use the /mapcreate command")
   public int minPermLevel = 2;
   
-  @Comment(value = "The ingredient to be held in the player's main hand when creating a map")
-  public CompoundTag mainHandIngredient = new ItemStack(Items.MAP, 1).toTag(new CompoundTag());
+  @Comment(value = "The item to be held in the player's main hand when creating a map")
+  public String mainHandIngredientId = "minecraft:map";
+  
+  @Comment(value = "The amount of the main hand ingredient consumed when creating a map")
+  public int mainHandIngredientAmount = 1;
   
   @Comment(value = "The ingredient to be held in the player's off hand when creating a map")
-  public CompoundTag offHandIngredient = new ItemStack(Items.INK_SAC, 1).toTag(new CompoundTag());
+  public String offHandIngredientId = "minecraft:black_dye";
+  
+  @Comment(value = "The amount of the off hand ingredient consumed when creating a map")
+  public int offHandIngredientAmount = 0;
 }


### PR DESCRIPTION
I was using this mod for a server and wanted the command to require ingredients when creating a map, so people couldn't obtain infinite maps with a command. Required items to be held in the players main hand and off hand can be set in the config. I've never used fabric, but am semi-familiar with forge, so I had some difficulty with displaying the ItemStack name and am not sure how messy that or the config stuff is, but it works to a basic extent as far as I know. I also wasn't trying to spend a lot of time doing this, I just thought it would be useful for my server, but also wanted to share it with you. Thank you for making this mod for fabric!