### PR TITLE
Implement Floyd-Steinberg Dithering

### DIFF
--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -8,9 +8,18 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.concurrent.CompletableFuture;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
 import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
@@ -24,58 +33,98 @@ import net.minecraft.util.math.Vec3d;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 
 public class Image2Map implements ModInitializer {
-    public static Image2MapConfig CONFIG = AutoConfig.register(Image2MapConfig.class, GsonConfigSerializer::new).getConfig();
+    public static Image2MapConfig CONFIG = AutoConfig.register(Image2MapConfig.class, GsonConfigSerializer::new)
+            .getConfig();
 
     @Override
     public void onInitialize() {
         System.out.println("Loading Image2Map...");
 
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> {
-            dispatcher.register(CommandManager.literal("mapcreate").requires(source -> source.hasPermissionLevel(CONFIG.minPermLevel))
-                    .then(CommandManager.argument("path", StringArgumentType.greedyString()).executes(context -> {
-                        ServerCommandSource source = context.getSource();
-                        Vec3d pos = source.getPosition();
-                        PlayerEntity player = source.getPlayer();
-                        String input = StringArgumentType.getString(context, "path");
-
-                        source.sendFeedback(new LiteralText("Generating image map..."), false);
-                        BufferedImage image;
-                        try {
-                            if (isValid(input)) {
-                                URL url = new URL(input);
-                                URLConnection connection = url.openConnection();
-                                connection.setRequestProperty("User-Agent", "Image2Map mod");
-                                connection.connect();
-                                image = ImageIO.read(connection.getInputStream());
-                            } else if (CONFIG.allowLocalFiles) {
-                                File file = new File(input);
-                                image = ImageIO.read(file);
-                            } else {
-                                image = null;
-                            }
-                        } catch (IOException e) {
-                            source.sendFeedback(new LiteralText("That doesn't seem to be a valid image."), false);
-                            return 0;
-                        }
-
-                        if (image == null) {
-                            source.sendFeedback(new LiteralText("That doesn't seem to be a valid image."), false);
-                            return 0;
-                        }
-
-                        ItemStack stack = MapRenderer.render(image, source.getWorld(), pos.x, pos.z, player);
-
-                        source.sendFeedback(new LiteralText("Done!"), false);
-                        if (!player.inventory.insertStack(stack)) {
-                            ItemEntity itemEntity = new ItemEntity(player.world, player.getPos().x, player.getPos().y,
-                                    player.getPos().z, stack);
-                            player.world.spawnEntity(itemEntity);
-                        }
-
-                        return 1;
-                    })));
+            dispatcher.register(CommandManager.literal("mapcreate")
+                    .requires(source -> source.hasPermissionLevel(CONFIG.minPermLevel))
+                    .then(CommandManager.argument("mode", StringArgumentType.word()).suggests(new DitherModeSuggestionProvider())
+                            .then(CommandManager.argument("path", StringArgumentType.greedyString())
+                                    .executes(this::createMap))));
         });
     }
+
+    class DitherModeSuggestionProvider implements SuggestionProvider<ServerCommandSource> {
+
+        @Override
+        public CompletableFuture<Suggestions> getSuggestions(CommandContext<ServerCommandSource> context,
+                SuggestionsBuilder builder) throws CommandSyntaxException {
+            builder.suggest("none");
+            builder.suggest("dither");
+            return builder.buildFuture();
+        }
+        
+    }
+
+    public enum DitherMode {
+        NONE,
+        FLOYD;
+
+        public static DitherMode fromString(String string) {
+            if (string.equalsIgnoreCase("NONE"))
+                return DitherMode.NONE;
+            else if (string.equalsIgnoreCase("DITHER") || string.equalsIgnoreCase("FLOYD"))
+                    return DitherMode.FLOYD;
+            throw new IllegalArgumentException("invalid dither mode");
+        }
+    }
+
+    private int createMap(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerCommandSource source = context.getSource();
+        Vec3d pos = source.getPosition();
+        PlayerEntity player = source.getPlayer();
+        DitherMode mode = null;
+        String modeStr = StringArgumentType.getString(context, "mode");
+        try {
+            mode = DitherMode.fromString(modeStr);
+        } catch (IllegalArgumentException e) {
+            throw new SimpleCommandExceptionType(() -> "Invalid dither mode '" + modeStr + "'").create();
+        }
+        String input = StringArgumentType.getString(context, "path");
+
+        source.sendFeedback(new LiteralText("Generating image map..."), false);
+        BufferedImage image;
+        try {
+            if (isValid(input)) {
+                URL url = new URL(input);
+                URLConnection connection = url.openConnection();
+                connection.setRequestProperty("User-Agent", "Image2Map mod");
+                connection.connect();
+                image = ImageIO.read(connection.getInputStream());
+            } else if (CONFIG.allowLocalFiles) {
+                File file = new File(input);
+                image = ImageIO.read(file);
+            } else {
+                image = null;
+            }
+        } catch (IOException e) {
+            source.sendFeedback(new LiteralText("That doesn't seem to be a valid image."), false);
+            return 0;
+        }
+
+        if (image == null) {
+            source.sendFeedback(new LiteralText("That doesn't seem to be a valid image."), false);
+            return 0;
+        }
+
+        ItemStack stack = MapRenderer.render(image, mode, source.getWorld(), pos.x, pos.z, player);
+
+        source.sendFeedback(new LiteralText("Done!"), false);
+        if (!player.inventory.insertStack(stack)) {
+            ItemEntity itemEntity = new ItemEntity(player.world, player.getPos().x, player.getPos().y,
+                    player.getPos().z, stack);
+            player.world.spawnEntity(itemEntity);
+        }
+
+        return 1;
+    }
+
+
 
     private static boolean isValid(String url) {
         try {

--- a/src/main/java/space/essem/image2map/renderer/MapRenderer.java
+++ b/src/main/java/space/essem/image2map/renderer/MapRenderer.java
@@ -6,6 +6,7 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.util.Arrays;
+import java.util.Objects;
 
 import net.minecraft.block.MaterialColor;
 import net.minecraft.entity.player.PlayerEntity;
@@ -14,94 +15,169 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.map.MapState;
 import net.minecraft.server.world.ServerWorld;
 
+import static space.essem.image2map.Image2Map.DitherMode;
+
 public class MapRenderer {
-  private static final double shadeCoeffs[] = { 0.71, 0.86, 1.0, 0.53 };
+    private static final double shadeCoeffs[] = { 0.71, 0.86, 1.0, 0.53 };
 
-  private static double distance(double[] vectorA, double[] vectorB) {
-    return Math.sqrt(Math.pow(vectorA[0] - vectorB[0], 2) + Math.pow(vectorA[1] - vectorB[1], 2)
-        + Math.pow(vectorA[2] - vectorB[2], 2));
-  }
+    private static double distance(double[] vectorA, double[] vectorB) {
+        return Math.sqrt(Math.pow(vectorA[0] - vectorB[0], 2) + Math.pow(vectorA[1] - vectorB[1], 2)
+                + Math.pow(vectorA[2] - vectorB[2], 2));
+    }
 
-  private static double[] applyShade(double[] color, int ind) {
-    double coeff = shadeCoeffs[ind];
-    return new double[] { color[0] * coeff, color[1] * coeff, color[2] * coeff };
-  }
+    private static double[] applyShade(double[] color, int ind) {
+        double coeff = shadeCoeffs[ind];
+        return new double[] { color[0] * coeff, color[1] * coeff, color[2] * coeff };
+    }
 
-  public static ItemStack render(BufferedImage image, ServerWorld world, double x, double z, PlayerEntity player) {
-    ItemStack stack = FilledMapItem.createMap(world, (int) x, (int) z, (byte) 3, false, false);
-    MapState state = FilledMapItem.getMapState(stack, world);
-    state.locked = true;
-    Image resizedImage = image.getScaledInstance(128, 128, Image.SCALE_DEFAULT);
-    BufferedImage resized = convertToBufferedImage(resizedImage);
-    int width = resized.getWidth();
-    int height = resized.getHeight();
-    int[][] pixels = convertPixelArray(resized);
-    MaterialColor[] colors = MaterialColor.COLORS;
-    Color imageColor;
-    colors = Arrays.stream(colors).filter(s -> s != null).toArray(MaterialColor[]::new);
+    public static ItemStack render(BufferedImage image, DitherMode mode, ServerWorld world, double x, double z,
+            PlayerEntity player) {
+        ItemStack stack = FilledMapItem.createMap(world, (int) x, (int) z, (byte) 3, false, false);
+        MapState state = FilledMapItem.getMapState(stack, world);
+        state.locked = true;
+        Image resizedImage = image.getScaledInstance(128, 128, Image.SCALE_DEFAULT);
+        BufferedImage resized = convertToBufferedImage(resizedImage);
+        int width = resized.getWidth();
+        int height = resized.getHeight();
+        int[][] pixels = convertPixelArray(resized);
+        MaterialColor[] mapColors = MaterialColor.COLORS;
+        Color imageColor;
+        mapColors = Arrays.stream(mapColors).filter(Objects::nonNull).toArray(MaterialColor[]::new);
 
-    for (int i = 0; i < width; i++) {
-      for (int j = 0; j < height; j++) {
-        imageColor = new Color(pixels[j][i], true);
+        for (int i = 0; i < width; i++) {
+            for (int j = 0; j < height; j++) {
+                imageColor = new Color(pixels[j][i], true);
+                if (mode.equals(DitherMode.FLOYD))
+                    state.colors[i + j * width] = (byte) floydDither(mapColors, pixels, i, j, imageColor);
+                else
+                    state.colors[i + j * width] = (byte) nearestColor(mapColors, imageColor);
+            }
+        }
+        return stack;
+    }
+    private static Color mapColorToRGBColor(MaterialColor[] colors, int color) {
+        Color mcColor = new Color(colors[color >> 2].color);
+        double[] mcColorVec = { 
+            (double) mcColor.getRed(), 
+            (double) mcColor.getGreen(),
+            (double) mcColor.getBlue()
+        };
+        double coeff = shadeCoeffs[color & 3];
+        return new Color((int)(mcColorVec[0] * coeff), (int)(mcColorVec[1] * coeff), (int)(mcColorVec[2] * coeff));
+    }
+
+    private static class NegatableColor {
+        public final int r;
+        public final int g;
+        public final int b;
+        public NegatableColor(int r, int g, int b) {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+        }
+    }
+    private static int floydDither(MaterialColor[] mapColors, int[][] pixels, int x, int y, Color imageColor) {
+        // double[] imageVec = { (double) imageColor.getRed() / 255.0, (double) imageColor.getGreen() / 255.0,
+        //         (double) imageColor.getBlue() / 255.0 };
+        int colorIndex = nearestColor(mapColors, imageColor);
+        Color palletedColor = mapColorToRGBColor(mapColors, colorIndex);
+        NegatableColor error = new NegatableColor(
+            imageColor.getRed() - palletedColor.getRed(),
+            imageColor.getGreen() - palletedColor.getGreen(),
+            imageColor.getBlue() - palletedColor.getBlue());
+        if (pixels[0].length > x + 1) {
+            Color pixelColor = new Color(pixels[y][x + 1], true);
+            pixels[y][x + 1] = applyError(pixelColor, error, 7.0 / 16.0);
+        }
+        if (pixels.length > y + 1) {
+            if (x > 0) {
+                Color pixelColor = new Color(pixels[y + 1][x - 1], true);
+                pixels[y + 1][x - 1] = applyError(pixelColor, error, 3.0 / 16.0);
+            }
+            Color pixelColor = new Color(pixels[y + 1][x], true);
+            pixels[y + 1][x] = applyError(pixelColor, error, 5.0 / 16.0);
+            if (pixels[0].length > x + 1) {
+                pixelColor = new Color(pixels[y + 1][x + 1], true);
+                pixels[y + 1][x + 1] = applyError(pixelColor, error, 1.0 / 16.0);
+            }
+        }
+            
+        
+        return colorIndex;
+    }
+
+    private static int applyError(Color pixelColor, NegatableColor error, double quantConst) {
+        int pR = clamp(pixelColor.getRed() + (int)((double)error.r * quantConst), 0, 255);
+        int pG = clamp(pixelColor.getGreen() + (int)((double)error.g * quantConst), 0, 255);
+        int pB = clamp(pixelColor.getBlue() + (int)((double)error.b * quantConst), 0, 255);
+        return new Color(pR, pG, pB, pixelColor.getAlpha()).getRGB();
+    }
+    private static int clamp(int i, int min, int max) {
+        if (min > max)
+            throw new IllegalArgumentException("max value cannot be less than min value");
+        if (i < min)
+            return min;
+        if (i > max)
+            return max;
+        return i;
+    }
+
+    private static int nearestColor(MaterialColor[] colors, Color imageColor) {
         double[] imageVec = { (double) imageColor.getRed() / 255.0, (double) imageColor.getGreen() / 255.0,
-            (double) imageColor.getBlue() / 255.0 };
-
+                (double) imageColor.getBlue() / 255.0 };
         int best_color = 0;
         double lowest_distance = 10000;
         for (int k = 0; k < colors.length; k++) {
-          Color mcColor = new Color(colors[k].color);
-          double[] mcColorVec = { (double) mcColor.getRed() / 255.0, (double) mcColor.getGreen() / 255.0,
-              (double) mcColor.getBlue() / 255.0 };
-          for (int shadeInd = 0; shadeInd < shadeCoeffs.length; shadeInd++) {
-            double distance = distance(imageVec, applyShade(mcColorVec, shadeInd));
-            if (distance < lowest_distance) {
-              lowest_distance = distance;
-              // todo: handle shading with alpha values other than 255
-              if (k == 0 && imageColor.getAlpha() == 255) {
-                best_color = 119;
-              } else {
-                best_color = k * shadeCoeffs.length + shadeInd;
-              }
+            Color mcColor = new Color(colors[k].color);
+            double[] mcColorVec = { (double) mcColor.getRed() / 255.0, (double) mcColor.getGreen() / 255.0,
+                    (double) mcColor.getBlue() / 255.0 };
+            for (int shadeInd = 0; shadeInd < shadeCoeffs.length; shadeInd++) {
+                double distance = distance(imageVec, applyShade(mcColorVec, shadeInd));
+                if (distance < lowest_distance) {
+                    lowest_distance = distance;
+                    // todo: handle shading with alpha values other than 255
+                    if (k == 0 && imageColor.getAlpha() == 255) {
+                        best_color = 119;
+                    } else {
+                        best_color = k * shadeCoeffs.length + shadeInd;
+                    }
+                }
             }
-          }
         }
-        state.colors[i + j * width] = (byte) best_color;
-      }
-    }
-    return stack;
-  }
-
-  private static int[][] convertPixelArray(BufferedImage image) {
-
-    final byte[] pixels = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
-    final int width = image.getWidth();
-    final int height = image.getHeight();
-
-    int[][] result = new int[height][width];
-    final int pixelLength = 4;
-    for (int pixel = 0, row = 0, col = 0; pixel + 3 < pixels.length; pixel += pixelLength) {
-      int argb = 0;
-      argb += (((int) pixels[pixel] & 0xff) << 24); // alpha
-      argb += ((int) pixels[pixel + 1] & 0xff); // blue
-      argb += (((int) pixels[pixel + 2] & 0xff) << 8); // green
-      argb += (((int) pixels[pixel + 3] & 0xff) << 16); // red
-      result[row][col] = argb;
-      col++;
-      if (col == width) {
-        col = 0;
-        row++;
-      }
+        return best_color;
     }
 
-    return result;
-  }
+    private static int[][] convertPixelArray(BufferedImage image) {
 
-  private static BufferedImage convertToBufferedImage(Image image) {
-    BufferedImage newImage = new BufferedImage(image.getWidth(null), image.getHeight(null),
-        BufferedImage.TYPE_4BYTE_ABGR);
-    Graphics2D g = newImage.createGraphics();
-    g.drawImage(image, 0, 0, null);
-    g.dispose();
-    return newImage;
-  }
+        final byte[] pixels = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
+        final int width = image.getWidth();
+        final int height = image.getHeight();
+
+        int[][] result = new int[height][width];
+        final int pixelLength = 4;
+        for (int pixel = 0, row = 0, col = 0; pixel + 3 < pixels.length; pixel += pixelLength) {
+            int argb = 0;
+            argb += (((int) pixels[pixel] & 0xff) << 24); // alpha
+            argb += ((int) pixels[pixel + 1] & 0xff); // blue
+            argb += (((int) pixels[pixel + 2] & 0xff) << 8); // green
+            argb += (((int) pixels[pixel + 3] & 0xff) << 16); // red
+            result[row][col] = argb;
+            col++;
+            if (col == width) {
+                col = 0;
+                row++;
+            }
+        }
+
+        return result;
+    }
+
+    private static BufferedImage convertToBufferedImage(Image image) {
+        BufferedImage newImage = new BufferedImage(image.getWidth(null), image.getHeight(null),
+                BufferedImage.TYPE_4BYTE_ABGR);
+        Graphics2D g = newImage.createGraphics();
+        g.drawImage(image, 0, 0, null);
+        g.dispose();
+        return newImage;
+    }
 }


### PR DESCRIPTION
This PR implements the floyd-steinberg dithering algorithm for generating maps.
As part of that, it changes the format of the `/mapcreate` command: instead of
```/mapcreate <link>```
The command is now formatted
```/mapcreate <mode> <link>```
where `mode` is either `none` or `dither`.
Example: 
![2021-02-17_16 09 26](https://user-images.githubusercontent.com/29683020/108275657-48e6e500-713c-11eb-9a4c-e0b40fee4d78.png)
(Floyd-Steinberg on the left, non-dithered on the right)