### PR TITLE
More survival friendly + bug fix

### DIFF
--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -335,8 +335,12 @@ public class Image2Map implements ModInitializer {
                     if (!entities.isEmpty()) {
                         var frame = entities.get(0);
 
-                        frame.setHeldItemStack(ItemStack.EMPTY, true);
-                        frame.setInvisible(false);
+                        // Only apply to frames that contain an image2map map
+                        var frameStack = frame.getHeldItemStack();
+                        if (frameStack.getItem() == Items.FILLED_MAP && tag != null && Arrays.stream(requiredTags).allMatch(tag::contains)) {
+                            frame.setHeldItemStack(ItemStack.EMPTY, true);
+                            frame.setInvisible(false);
+                        }
                     }
                 }
             }

--- a/src/main/java/space/essem/image2map/Image2Map.java
+++ b/src/main/java/space/essem/image2map/Image2Map.java
@@ -12,6 +12,8 @@ import com.mojang.logging.LogUtils;
 import eu.pb4.sgui.api.GuiHelpers;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -28,6 +30,8 @@ import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
+
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import space.essem.image2map.config.Image2MapConfig;
 import space.essem.image2map.gui.PreviewGui;
@@ -38,6 +42,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -179,7 +184,6 @@ public class Image2Map implements ModInitializer {
                 height = image.getHeight();
             }
 
-
             int finalHeight = height;
             int finalWidth = width;
             source.sendFeedback(Text.literal("Converting into maps..."), false);
@@ -272,11 +276,67 @@ public class Image2Map implements ModInitializer {
                     var x = map.getNbt().getInt("image2map:x");
                     var y = map.getNbt().getInt("image2map:y");
 
+                    map.getNbt().putString("image2map:right", right.asString());
+                    map.getNbt().putString("image2map:down", down.asString());
+                    map.getNbt().putString("image2map:facing", facing.asString());
+
                     var frame = frames[x + y * width];
 
                     if (frame != null && frame.getHeldItemStack().isEmpty()) {
                         frame.setHeldItemStack(map);
                         frame.setRotation(rot);
+                        frame.setInvisible(true);
+                    }
+                }
+            }
+
+            stack.decrement(1);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public static boolean destroyItemFrame(Entity player, ItemFrameEntity itemFrameEntity) {
+        var stack = itemFrameEntity.getHeldItemStack();
+        var tag = stack.getNbt();
+
+        String[] requiredTags = new String[] { "image2map:x", "image2map:y", "image2map:width", "image2map:height",
+                "image2map:right", "image2map:down", "image2map:facing" };
+
+        if (stack.getItem() == Items.FILLED_MAP && tag != null && Arrays.stream(requiredTags).allMatch(tag::contains)) {
+            var xo = tag.getInt("image2map:x");
+            var yo = tag.getInt("image2map:y");
+            var width = tag.getInt("image2map:width");
+            var height = tag.getInt("image2map:height");
+
+            Direction right = Direction.byName(tag.getString("image2map:right"));
+            Direction down = Direction.byName(tag.getString("image2map:down"));
+            Direction facing = Direction.byName(tag.getString("image2map:facing"));
+
+            var world = itemFrameEntity.world;
+            var start = itemFrameEntity.getBlockPos();
+
+            var mut = start.mutableCopy();
+
+            mut.move(right, -xo);
+            mut.move(down, -yo);
+
+            start = mut.toImmutable();
+
+            for (var x = 0; x < width; x++) {
+                for (var y = 0; y < height; y++) {
+                    mut.set(start);
+                    mut.move(right, x);
+                    mut.move(down, y);
+                    var entities = world.getEntitiesByClass(ItemFrameEntity.class, Box.from(Vec3d.of(mut)),
+                            (entity1) -> entity1.getHorizontalFacing() == facing && entity1.getBlockPos().equals(mut));
+                    if (!entities.isEmpty()) {
+                        var frame = entities.get(0);
+
+                        frame.setHeldItemStack(ItemStack.EMPTY, true);
+                        frame.setInvisible(false);
                     }
                 }
             }
@@ -286,7 +346,6 @@ public class Image2Map implements ModInitializer {
 
         return false;
     }
-
 
     private static boolean isValid(String url) {
         try {

--- a/src/main/java/space/essem/image2map/gui/MapGui.java
+++ b/src/main/java/space/essem/image2map/gui/MapGui.java
@@ -27,6 +27,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.GameMode;
+import java.util.Collections;
 import org.jetbrains.annotations.Nullable;
 
 
@@ -144,7 +145,7 @@ public class MapGui extends HotbarGui {
             this.player.networkHandler.sendPacket(new EntitiesDestroyS2CPacket(this.additionalEntities));
         }
         this.player.networkHandler.sendPacket(new GameStateChangeS2CPacket(GameStateChangeS2CPacket.GAME_MODE_CHANGED, this.player.interactionManager.getGameMode().getId()));
-        this.player.networkHandler.sendPacket(new EntityPositionS2CPacket(this.player));
+        this.player.networkHandler.sendPacket(new PlayerPositionLookS2CPacket(this.player.getX(), this.player.getY(), this.player.getZ(), this.player.getYaw(), this.player.getPitch(), Collections.emptySet(), 0, false));
 
         super.onClose();
     }

--- a/src/main/java/space/essem/image2map/mixin/BundleItemMixin.java
+++ b/src/main/java/space/essem/image2map/mixin/BundleItemMixin.java
@@ -1,0 +1,55 @@
+package space.essem.image2map.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.StackReference;
+import net.minecraft.item.BundleItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.ClickType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.world.World;
+
+@Mixin(BundleItem.class)
+public class BundleItemMixin {
+
+  @Inject(method = "use", at = @At("HEAD"), cancellable = true)
+  private void image2map$useBundle(World world, PlayerEntity user, Hand hand,
+      CallbackInfoReturnable<TypedActionResult<ItemStack>> cir) {
+    ItemStack itemStack = user.getStackInHand(hand);
+    var tag = itemStack.getNbt();
+
+    if (tag != null && tag.contains("image2map:quick_place")) {
+      cir.setReturnValue(TypedActionResult.fail(itemStack));
+      cir.cancel();
+    }
+  }
+
+  @Inject(method = "onStackClicked", at = @At("HEAD"), cancellable = true)
+  private void image2map$addBundleItems(ItemStack bundle, Slot slot, ClickType clickType, PlayerEntity player,
+      CallbackInfoReturnable<Boolean> cir) {
+    var tag = bundle.getNbt();
+
+    if (tag != null && tag.contains("image2map:quick_place")) {
+      cir.setReturnValue(false);
+      cir.cancel();
+    }
+  }
+
+  @Inject(method = "onClicked", at = @At("HEAD"), cancellable = true)
+  private void image2map$removeBundleItems(ItemStack bundle, ItemStack otherStack, Slot slot, ClickType clickType,
+      PlayerEntity player, StackReference cursorStackReference,
+      CallbackInfoReturnable<Boolean> cir) {
+    var tag = bundle.getNbt();
+
+    if (tag != null && tag.contains("image2map:quick_place")) {
+      cir.setReturnValue(false);
+      cir.cancel();
+    }
+  }
+}

--- a/src/main/java/space/essem/image2map/mixin/ItemFrameEntityMixin.java
+++ b/src/main/java/space/essem/image2map/mixin/ItemFrameEntityMixin.java
@@ -1,24 +1,43 @@
 package space.essem.image2map.mixin;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.decoration.ItemFrameEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import space.essem.image2map.Image2Map;
 
 @Mixin(ItemFrameEntity.class)
 public class ItemFrameEntityMixin {
-    @Shadow private boolean fixed;
+    @Shadow
+    private boolean fixed;
 
     @Inject(method = "interact", at = @At("HEAD"), cancellable = true)
     private void image2map$fillMaps(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> cir) {
         if (!this.fixed && Image2Map.clickItemFrame(player, hand, (ItemFrameEntity) (Object) this)) {
             cir.setReturnValue(ActionResult.SUCCESS);
+        }
+    }
+
+    @Inject(method = "dropHeldStack", at = @At("HEAD"), cancellable = true)
+    private void image2map$destroyMaps(@Nullable Entity entity, boolean alwaysDrop,
+            CallbackInfo ci) {
+        var frame = (ItemFrameEntity) (Object) this;
+
+        if (!this.fixed && Image2Map.destroyItemFrame(entity, frame)) {
+            if (alwaysDrop)
+                frame.dropStack(new ItemStack(Items.ITEM_FRAME));
+            ci.cancel();
         }
     }
 }

--- a/src/main/java/space/essem/image2map/renderer/MapRenderer.java
+++ b/src/main/java/space/essem/image2map/renderer/MapRenderer.java
@@ -10,7 +10,6 @@ import java.util.List;
 import eu.pb4.mapcanvas.api.core.CanvasColor;
 import eu.pb4.mapcanvas.api.core.CanvasImage;
 import eu.pb4.mapcanvas.api.utils.CanvasUtils;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.FilledMapItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -94,6 +93,8 @@ public class MapRenderer {
                 lore.add(NbtString.of(Text.Serializer.toJson(Text.literal(url))));
                 stack.getOrCreateNbt().putInt("image2map:x", xs);
                 stack.getOrCreateNbt().putInt("image2map:y", ys);
+                stack.getOrCreateNbt().putInt("image2map:width", xSections);
+                stack.getOrCreateNbt().putInt("image2map:height", ySections);
                 stack.getOrCreateSubNbt("display").put("Lore", lore);
                 items.add(stack);
             }
@@ -148,7 +149,6 @@ public class MapRenderer {
         double coeff = shadeCoeffs[color.getColor().id & 3];
         return ColorHelper.Argb.getArgb(0, (int) (mcColorVec[0] * coeff), (int) (mcColorVec[1] * coeff), (int) (mcColorVec[2] * coeff));
     }
-
 
     private static CanvasColor floydDither(int[][] pixels, int x, int y, int imageColor) {
         var closestColor = CanvasUtils.findClosestColorARGB(imageColor);

--- a/src/main/resources/image2map.mixins.json
+++ b/src/main/resources/image2map.mixins.json
@@ -5,10 +5,10 @@
   "mixins": [
     "ItemFrameEntityMixin",
     "PlayerEntityMixin",
-    "ServerPlayNetworkHandlerMixin"
+    "ServerPlayNetworkHandlerMixin",
+    "BundleItemMixin",
   ],
-  "server": [
-  ],
+  "server": [],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
This PR aims to aid users who want to use this mod in a more survival friendly setting.

* Bundles will now be consumed (in survival/adventure mode) when placed
* Bundles made by image2map can no longer be used outside of placing the image onto item frames
* Removing a single frame from a multi-frame images clears the image in its entirety (this includes when it is destroyed by other means, e.g. explosions, water, etc)
* The item frames are now made invisible to allow better use of PNG (transparent) images
* Leaving the preview GUI no longer kills the player in survival (Fixes #24)